### PR TITLE
fix(TRI-292): fixing appcues flow initiation

### DIFF
--- a/js/amplitudeEvents.js
+++ b/js/amplitudeEvents.js
@@ -9,9 +9,9 @@ function amplitudeInit(isFromCoveoDev, userId) {
 
 
 document.addEventListener("DOMContentLoaded", function() {
-const userId = localStorage.getItem('userId')
-const isFromCoveoDev = localStorage.getItem('coveoDev')
-if(userId) {
-    amplitudeInit(isFromCoveoDev, userId)
-}
+    const userId = localStorage.getItem('userId')
+    const isFromCoveoDev = localStorage.getItem('coveoDev')
+    if(userId) {
+        amplitudeInit(isFromCoveoDev, userId)
+    }
 })

--- a/js/appcuesEvents.js
+++ b/js/appcuesEvents.js
@@ -1,14 +1,7 @@
-function appcuesInit(orgId) {
-  Appcues.identify(orgId);
-}
-
 document.addEventListener("DOMContentLoaded", function () {
   const orgId = localStorage.getItem("organizationId");
-  const isFromCoveoDev = localStorage.getItem("coveoDev");
 
-  if (orgId) {
-    appcuesInit(orgId, isFromCoveoDev);
-  }
+  Appcues.identify(orgId ?? 'triggerFlowPlaceHolderID')
 });
 
 Appcues.on("flow_started", () => {


### PR DESCRIPTION
This removes the check for orgId in appcues which was not needed.

Will use the method to always trigger the Appcues flow on load regardless of the local storage information.

All other functionalities remain untouched meaning the explore Coveo will still redirect to the orgId if the user came from the orgid